### PR TITLE
feat(build): support templated build names

### DIFF
--- a/docs/src/content/docs/config/config.md
+++ b/docs/src/content/docs/config/config.md
@@ -200,7 +200,7 @@ Templating can be used in the following configuration fields:
 
 - Release hooks: `hooks.before`, `hooks.after`
 - Release env values: `env`
-- Build fields: `command`, `bin_name`, `artifact`, `archive_name`, `prehook`, `posthook`
+- Build fields: `name`, `command`, `bin_name`, `artifact`, `archive_name`, `prehook`, `posthook`
 - Build env values: `env`
 - Additional files: release and build `additional_files`
 - Docker image: `targets.docker.image`, `targets.docker.images`

--- a/docs/src/content/docs/templating.md
+++ b/docs/src/content/docs/templating.md
@@ -10,7 +10,7 @@ Rlsr uses Minijinja (Jinja2-compatible) for templating. Use `{{ ... }}` for valu
 Templating is supported in:
 - Release hooks: `hooks.before`, `hooks.after`
 - Release env values: `env`
-- Build fields: `command`, `bin_name`, `artifact`, `archive_name`, `prehook`, `posthook`
+- Build fields: `name`, `command`, `bin_name`, `artifact`, `archive_name`, `prehook`, `posthook`
 - Build env values: `env`
 - Additional files: release and build `additional_files`
 - Docker target images: `targets.docker.image`, `targets.docker.images`


### PR DESCRIPTION
## Summary
- render templated build names before running build steps
- propagate rendered build names into buildx error handling
- document build name templating and add coverage

## Testing
- cargo fmt
- cargo clippy
- cargo test

Fixes #3