### PR TITLE
feat: support different archive formats other than zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,8 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -466,6 +468,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "flate2"
@@ -990,6 +1003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.7.0",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1117,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "md-5"
@@ -1305,7 +1347,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1565,6 +1607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,10 +1716,12 @@ dependencies = [
  "color-eyre",
  "config",
  "env_logger",
+ "flate2",
  "futures",
  "hyper-rustls",
  "infer",
  "log",
+ "lz4_flex",
  "md-5",
  "minijinja",
  "octocrab",
@@ -1681,11 +1734,13 @@ dependencies = [
  "sha1",
  "sha2",
  "sha3",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-util",
  "yaml-rust",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -2095,6 +2150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2448,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -2814,6 +2886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,4 +3017,32 @@ dependencies = [
  "log",
  "once_cell",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ zip = { version = "2.4", default-features = false, features = [
     "deflate",
     "bzip2",
 ] }
+tar = "0.4"
+flate2 = "1.0"
+zstd = "0.13"
+lz4_flex = "0.11"
 async-trait = "0.1"
 color-eyre = { version = "0.6", default-features = false }
 camino = "1.0.9"

--- a/docs/src/content/docs/config/config.md
+++ b/docs/src/content/docs/config/config.md
@@ -38,24 +38,29 @@ releases:
       - command: "just build-linux"
         artifact: "target/x86_64-unknown-linux-gnu/release/rlsr"
         archive_name: "rlsr-{{ meta.tag }}-linux-x86_64"
+        archive_format: tar_gz  # Use tar.gz instead of zip
         name: "Linux build"
         env:
           - "BIN_NAME=rlsr.bin"
       - command: "just build-macos"
         artifact: "target/aarch64-apple-darwin/release/rlsr"
         archive_name: "rlsr-{{ meta.tag }}-macos-arm64"
+        archive_format: tar_gz
         name: "MacOS build"
       - command: "just build-windows"
         artifact: "target/x86_64-pc-windows-gnu/release/rlsr.exe"
         archive_name: "rlsr-{{ meta.tag }}-windows-x86_64"
+        # archive_format defaults to zip, good for Windows
         name: "Windows build"
       - command: "just build-freebsd"
         artifact: "target/x86_64-unknown-freebsd/release/rlsr"
         archive_name: "rlsr-{{ meta.tag }}-freebsd-x86_64"
+        archive_format: tar_zstd  # Zstandard for better compression
         name: "FreeBSD build"
       - command: "just build-linux-arm64"
         artifact: "target/aarch64-unknown-linux-musl/release/rlsr"
         archive_name: "rlsr-{{ meta.tag }}-linux-arm64"
+        archive_format: tar_gz
         name: "Linux ARM64 build"
 changelog:
   format: "github"
@@ -128,6 +133,11 @@ The `builds` section is an array that defines one or more build configurations. 
 - `bin_name`: (Optional) The name of the binary produced.
 - `artifact`: The path to the built artifact.
 - `archive_name`: The name of the archive containing the artifact.
+- `archive_format`: (Optional) The archive format to use. Defaults to `zip`. Supported formats:
+  - `zip`: Standard ZIP archive (default)
+  - `tar_gz` or `"tar.gz"`: Gzip-compressed tar archive
+  - `tar_zstd` or `"tar.zstd"`: Zstandard-compressed tar archive
+  - `tar_lz4` or `"tar.lz4"`: LZ4-compressed tar archive
 - `os`: (Optional) The target operating system label.
 - `arch`: (Optional) The target architecture label.
 - `arm`: (Optional) The ARM version label.

--- a/rlsr.sample.yml
+++ b/rlsr.sample.yml
@@ -34,6 +34,10 @@ releases:
         archive_name: "rlsr-linux-x86_64" # Archive name.
         no_archive: false # If turned true, will not archive the artifact.
 
+        # Archive format: zip (default), tar_gz, tar_zstd, or tar_lz4.
+        # Can also use "tar.gz", "tar.zstd", "tar.lz4" with quotes.
+        archive_format: tar_gz
+
         prehook: "generate_docs.sh" # Optional, a script to run before the build.
         posthook: "posthook.sh"
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -263,11 +263,16 @@ async fn process_artifacts(
 
         let files = prepare_archive_files(release, build, &artifact, &bin_path, build_meta).await?;
 
-        let zip_path = archive_files(files, release.dist_folder.clone(), archive_name.clone())
-            .await
-            .with_context(|| format!("error while creating archive for build: {}", archive_name))?;
+        let archive_path = archive_files(
+            files,
+            release.dist_folder.clone(),
+            archive_name.clone(),
+            build.archive_format,
+        )
+        .await
+        .with_context(|| format!("error while creating archive for build: {}", archive_name))?;
 
-        Ok(zip_path)
+        Ok(archive_path)
     } else {
         // Copy artifact with the final name
         copy_artifact_with_name(release, &artifact, &archive_name).await?;
@@ -368,7 +373,7 @@ async fn copy_artifact_with_name(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{BuildType, ReleaseTargets};
+    use crate::config::{ArchiveFormat, BuildType, ReleaseTargets};
     use crate::TemplateMeta;
     use std::collections::BTreeMap;
 
@@ -434,6 +439,7 @@ mod tests {
             posthook: None,
             no_archive: None,
             additional_files: None,
+            archive_format: ArchiveFormat::default(),
         }
     }
 

--- a/src/buildx.rs
+++ b/src/buildx.rs
@@ -250,7 +250,7 @@ pub(crate) async fn ensure_buildx_builder(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{BuildType, BuildxConfig};
+    use crate::config::{ArchiveFormat, BuildType, BuildxConfig};
     use serde::Serialize;
     use std::collections::HashMap;
 
@@ -314,6 +314,7 @@ mod tests {
             posthook: None,
             no_archive: None,
             additional_files: None,
+            archive_format: ArchiveFormat::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,6 +912,7 @@ impl std::fmt::Display for HookType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ArchiveFormat;
 
     fn base_build(build_type: BuildType) -> Build {
         Build {
@@ -932,6 +933,7 @@ mod tests {
             posthook: None,
             no_archive: None,
             additional_files: None,
+            archive_format: ArchiveFormat::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

This PR implements support for different archive formats as requested in #5.

### Changes

- **New `ArchiveFormat` enum** with variants:
  - `zip` (default, existing behavior)
  - `tar_gz` / `tar.gz` - Gzip-compressed tar
  - `tar_zstd` / `tar.zstd` - Zstandard-compressed tar
  - `tar_lz4` / `tar.lz4` - LZ4-compressed tar

- **New dependencies**:
  - `tar` - for creating tar archives
  - `flate2` - for gzip compression
  - `zstd` - for zstandard compression
  - `lz4_flex` - for LZ4 compression (pure Rust)

- **New `archive_format` field** in build config (defaults to `zip` for backward compatibility)

### Usage

```yaml
builds:
  - command: "cargo build --release"
    artifact: "./target/release/myapp"
    archive_name: "myapp-linux-x86_64"
    archive_format: tar_gz  # or "tar.gz", tar_zstd, tar_lz4, zip
```

### Testing

- Added unit tests for all archive format creation functions
- Added config parsing tests for all format variants including dot-notation aliases
- All 47 tests pass

Closes #5