### PR TITLE
feat(release): add GitLab Releases support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "urlencoding",
  "yaml-rust",
  "zip",
  "zstd",
@@ -2505,6 +2506,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
     "multipart",
     "rustls-tls-webpki-roots",
+    "json",
 ] }
 infer = "0.7.0"
 zip = { version = "2.4", default-features = false, features = [
@@ -53,6 +54,7 @@ minijinja = {version = "2.2.0", features = ["loader", "builtins"] }
 ring = "0.17.14"
 semver = "1.0.25"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+urlencoding = "2.1"
 
 [dev-dependencies]
 tempfile = { version = "3.19" }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
           items: [
             { label: "Configuration", slug: "config/config" },
             { label: "Release Targets", slug: "config/targets" },
+            { label: "GitLab Releases", slug: "config/gitlab" },
             { label: "Templating", slug: "templating" },
           ],
         },

--- a/docs/src/content/docs/config/config.md
+++ b/docs/src/content/docs/config/config.md
@@ -93,7 +93,7 @@ The `releases` section is an array that can contain one or more release configur
 
 The `targets` subsection specifies where the releases will be published. Rlsr supports multiple target types, including GitHub and Docker.
 
-For detailed information on configuring targets, please refer to the [Release Targets Configuration](./targets) page.
+For detailed information on configuring targets, please refer to the [Release Targets Configuration](/config/targets) page.
 
 ### Checksum
 

--- a/docs/src/content/docs/config/gitlab.md
+++ b/docs/src/content/docs/config/gitlab.md
@@ -1,0 +1,59 @@
+---
+title: GitLab Releases 🦊
+description: How to configure GitLab releases in Rlsr.
+---
+
+Rlsr can publish releases directly to GitLab by configuring the `gitlab` target in your release configuration.
+
+## Configure the GitLab Target
+
+Add a `gitlab` entry under `targets`:
+
+```yaml
+targets:
+  gitlab:
+    owner: "namespace" # or username
+    repo: "project-name"
+    url: "https://gitlab.com" # optional, defaults to gitlab.com
+```
+
+- `owner`: The GitLab group/namespace or username that owns the project.
+- `repo`: The GitLab project name.
+- `url`: The GitLab instance URL (optional, defaults to `https://gitlab.com`). Use this for self-hosted GitLab instances.
+
+## Authentication
+
+Set the `GITLAB_TOKEN` environment variable with a GitLab Personal Access Token that has the **api** scope. Rlsr uses this token to create releases and upload assets.
+
+## Example Configuration
+
+```yaml
+releases:
+  - name: "Release to GitLab"
+    dist_folder: "./dist"
+    targets:
+      gitlab:
+        owner: "namespace"
+        repo: "project-name"
+    builds:
+      - command: "cargo build --release"
+        artifact: "./target/release/app"
+        archive_name: "app-{{ meta.tag }}-linux-x86_64"
+        archive_format: tar_gz
+```
+
+## Self-Hosted GitLab
+
+For self-hosted GitLab instances, specify the `url` field:
+
+```yaml
+targets:
+  gitlab:
+    owner: "myteam"
+    repo: "myproject"
+    url: "https://gitlab.example.com"
+```
+
+## Asset Handling
+
+Build artifacts are uploaded as GitLab **generic packages** and then attached to the release as asset links. The release page will link to the package files stored in the GitLab Package Registry.

--- a/docs/src/content/docs/config/targets.md
+++ b/docs/src/content/docs/config/targets.md
@@ -10,7 +10,8 @@ The `targets` subsection in your Rlsr configuration specifies where the releases
 Currently, Rlsr supports the following targets:
 
 1. GitHub
-2. Docker
+2. GitLab
+3. Docker
 
 Let's explore each target type in detail.
 
@@ -31,6 +32,28 @@ targets:
 ### Important Note
 
 To release to GitHub, you must set the `GITHUB_TOKEN` environment variable with a valid GitHub Personal Access Token. This token is used to authenticate and perform release operations on your GitHub repository.
+
+## GitLab
+
+To release to GitLab, you need to specify the following in your configuration:
+
+```yaml
+targets:
+  gitlab:
+    owner: "namespace"
+    repo: "project-name"
+    url: "https://gitlab.com" # optional, for self-hosted instances
+```
+
+- `owner`: The GitLab group/namespace or username where the project lives.
+- `repo`: The GitLab project name.
+- `url`: The GitLab instance URL (optional, defaults to `https://gitlab.com`).
+
+### Important Note
+
+To release to GitLab, you must set the `GITLAB_TOKEN` environment variable with a valid GitLab Personal Access Token that has the **api** scope.
+
+For more details on GitLab behavior, see [GitLab Releases](/config/gitlab).
 
 ## Docker
 

--- a/rlsr.sample.yml
+++ b/rlsr.sample.yml
@@ -8,6 +8,10 @@ releases:
       github:
         owner: "iamd3vil"
         repo: "rlsr"
+      gitlab:
+        owner: "namespace" # or username
+        repo: "project-name"
+        # url: "https://gitlab.example.com" # Optional: for self-hosted GitLab (defaults to https://gitlab.com)
       docker:
         image: "localhost:5000/rlsr"
         dockerfile: "./Dockerfile"

--- a/src/build.rs
+++ b/src/build.rs
@@ -410,6 +410,7 @@ mod tests {
             builds: Vec::new(),
             targets: ReleaseTargets {
                 github: None,
+                gitlab: None,
                 docker: None,
             },
             checksum: None,

--- a/src/release_provider/gitlab.rs
+++ b/src/release_provider/gitlab.rs
@@ -1,0 +1,261 @@
+use crate::config::{Changelog, Release};
+use crate::release_provider::ReleaseProvider;
+use crate::utils::{get_all_git_log, get_all_tags, get_changelog};
+use async_trait::async_trait;
+use camino::Utf8Path;
+use color_eyre::eyre::{bail, Context, Result};
+use log::{debug, error, info};
+use reqwest::{Body, Client};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::fs;
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+#[async_trait]
+impl ReleaseProvider for Gitlab {
+    async fn publish(
+        &self,
+        release: &Release,
+        all_archives: Vec<String>,
+        _image_tags: Vec<String>,
+        latest_tag: String,
+    ) -> Result<()> {
+        self.publish_build(release, all_archives, self.token.clone(), latest_tag)
+            .await
+            .with_context(|| {
+                format!(
+                    "error publishing release to gitlab for release: {}",
+                    release.name
+                )
+            })?;
+        Ok(())
+    }
+}
+
+pub struct Gitlab {
+    token: String,
+    changelog: Changelog,
+}
+
+impl Gitlab {
+    pub fn new(token: String, changelog: Changelog) -> Self {
+        Gitlab { token, changelog }
+    }
+
+    async fn publish_build(
+        &self,
+        release: &Release,
+        all_archives: Vec<String>,
+        token: String,
+        latest_tag: String,
+    ) -> Result<()> {
+        let gl = match &release.targets.gitlab {
+            Some(gl) => gl,
+            None => {
+                bail!("gitlab config is blank, skipping publishing");
+            }
+        };
+
+        debug!("creating release in {}/{}", gl.owner, gl.repo);
+
+        if token.is_empty() {
+            bail!("GITLAB_TOKEN is blank, skipping publishing build");
+        }
+
+        // URL-encode the project path (owner/repo)
+        let project_path = format!("{}/{}", gl.owner, gl.repo);
+        let encoded_project = urlencoding::encode(&project_path);
+        let base_url = gl.url.trim_end_matches('/');
+
+        // Get changelog.
+        let tags = get_all_tags().await?;
+        let changelog = if tags.len() == 1 {
+            get_all_git_log().await?
+        } else {
+            get_changelog(&self.changelog).await?
+        };
+
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::limited(100))
+            .build()?;
+        let client = Arc::new(client);
+
+        // First, upload all archives as generic package files and collect their URLs
+        let mut asset_links = Vec::new();
+
+        let mut checksum_path = Utf8Path::new(&release.dist_folder)
+            .join("checksums.txt")
+            .to_string();
+        if release.checksum.is_none() {
+            checksum_path = String::from("");
+        }
+
+        // Upload archives
+        for archive in &all_archives {
+            let filename = Utf8Path::new(archive)
+                .file_name()
+                .unwrap_or("artifact")
+                .to_string();
+
+            let download_url = Self::upload_package_file(
+                client.clone(),
+                base_url,
+                &encoded_project,
+                &token,
+                &latest_tag,
+                archive,
+                &filename,
+            )
+            .await
+            .with_context(|| format!("error uploading archive {}", archive))?;
+
+            asset_links.push(AssetLink {
+                name: filename,
+                url: download_url,
+                link_type: "package".to_string(),
+            });
+        }
+
+        // Upload checksum file if it exists
+        if !checksum_path.is_empty() && tokio::fs::metadata(&checksum_path).await.is_ok() {
+            debug!("uploading checksums file");
+            let download_url = Self::upload_package_file(
+                client.clone(),
+                base_url,
+                &encoded_project,
+                &token,
+                &latest_tag,
+                &checksum_path,
+                "checksums.txt",
+            )
+            .await
+            .with_context(|| "error uploading checksum file")?;
+
+            asset_links.push(AssetLink {
+                name: "checksums.txt".to_string(),
+                url: download_url,
+                link_type: "other".to_string(),
+            });
+        }
+
+        // Create the release with asset links
+        let create_release_url = format!(
+            "{}/api/v4/projects/{}/releases",
+            base_url, encoded_project
+        );
+
+        let release_request = CreateReleaseRequest {
+            tag_name: latest_tag.clone(),
+            description: changelog,
+            assets: ReleaseAssets {
+                links: asset_links,
+            },
+        };
+
+        debug!("creating gitlab release for tag: {}", latest_tag);
+        let res = client
+            .post(&create_release_url)
+            .header("PRIVATE-TOKEN", &token)
+            .header("Content-Type", "application/json")
+            .json(&release_request)
+            .send()
+            .await
+            .context("error creating release in gitlab")?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let error_body = res.text().await.unwrap_or_default();
+            error!("gitlab release creation failed: {} - {}", status, error_body);
+            bail!(
+                "error creating gitlab release, status: {}, error: {}",
+                status,
+                error_body
+            );
+        }
+
+        info!("gitlab release created successfully");
+        Ok(())
+    }
+
+    /// Upload a file to GitLab's generic package registry and return the download URL
+    async fn upload_package_file(
+        client: Arc<Client>,
+        base_url: &str,
+        encoded_project: &str,
+        token: &str,
+        version: &str,
+        filepath: &str,
+        filename: &str,
+    ) -> Result<String> {
+        // Sanitize version for package registry (remove 'v' prefix if present)
+        let package_version = version.strip_prefix('v').unwrap_or(version);
+
+        // Upload URL for generic packages
+        let upload_url = format!(
+            "{}/api/v4/projects/{}/packages/generic/release/{}/{}",
+            base_url, encoded_project, package_version, filename
+        );
+
+        debug!("uploading file {} to {}", filepath, upload_url);
+
+        // Get file size
+        let meta = fs::metadata(filepath)
+            .await
+            .context("error getting file metadata")?;
+        let size = meta.len();
+
+        // Open file and create streaming body
+        let file = tokio::fs::File::open(filepath).await?;
+        let stream = FramedRead::new(file, BytesCodec::new());
+        let body = Body::wrap_stream(stream);
+
+        let res = client
+            .put(&upload_url)
+            .header("PRIVATE-TOKEN", token)
+            .header("Content-Length", size)
+            .body(body)
+            .send()
+            .await
+            .context("error uploading file to gitlab")?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let error_body = res.text().await.unwrap_or_default();
+            bail!(
+                "error uploading to gitlab package registry, status: {}, error: {}",
+                status,
+                error_body
+            );
+        }
+
+        // Construct the download URL (GitLab returns just {"message": "201 Created"})
+        let download_url = format!(
+            "{}/api/v4/projects/{}/packages/generic/release/{}/{}",
+            base_url, encoded_project, package_version, filename
+        );
+
+        debug!("file uploaded successfully: {}", download_url);
+        Ok(download_url)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CreateReleaseRequest {
+    tag_name: String,
+    description: String,
+    assets: ReleaseAssets,
+}
+
+#[derive(Debug, Serialize)]
+struct ReleaseAssets {
+    links: Vec<AssetLink>,
+}
+
+#[derive(Debug, Serialize)]
+struct AssetLink {
+    name: String,
+    url: String,
+    link_type: String,
+}
+
+

--- a/src/release_provider/mod.rs
+++ b/src/release_provider/mod.rs
@@ -4,6 +4,7 @@ use color_eyre::eyre::Result;
 
 pub mod docker;
 pub mod github;
+pub mod gitlab;
 
 /// ReleaseProvider is the trait which needs to be implemented for all the
 /// different types of release targets. For example, we can implement a provider

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,7 @@ use zip::DateTime;
 use crate::changelog_formatter;
 use crate::config::{ArchiveFormat, Changelog, Release};
 use crate::release_provider::github::Github;
+use crate::release_provider::gitlab::Gitlab;
 use crate::release_provider::{docker, ReleaseProvider};
 use regex::Regex;
 
@@ -57,8 +58,15 @@ pub fn get_release_providers(
     // Check if github details are provided.
     if release.targets.github.is_some() {
         let ghtoken = get_github_token();
-        let gh = Github::new(ghtoken, changelog.unwrap_or_default());
+        let gh = Github::new(ghtoken, changelog.clone().unwrap_or_default());
         providers.push(Box::new(gh));
+    }
+
+    // Check if gitlab details are provided.
+    if release.targets.gitlab.is_some() {
+        let gltoken = get_gitlab_token();
+        let gl = Gitlab::new(gltoken, changelog.clone().unwrap_or_default());
+        providers.push(Box::new(gl));
     }
 
     if release.targets.docker.is_some() {
@@ -262,6 +270,11 @@ pub async fn get_changelog(cfg: &Changelog) -> Result<String> {
 pub fn get_github_token() -> String {
     // Check if `GITHUB_TOKEN` is present.
     env::var("GITHUB_TOKEN").unwrap_or_else(|_| String::new())
+}
+
+pub fn get_gitlab_token() -> String {
+    // Check if `GITLAB_TOKEN` is present.
+    env::var("GITLAB_TOKEN").unwrap_or_else(|_| String::new())
 }
 
 pub async fn is_repo_clean() -> Result<bool> {


### PR DESCRIPTION
## Summary
Adds support for publishing releases to GitLab, closing #7.

## Changes
- Add new GitLab release provider (`src/release_provider/gitlab.rs`)
- Upload assets to GitLab Generic Package Registry
- Link uploaded packages to releases as asset links
- Support `GITLAB_TOKEN` environment variable for authentication
- Add `Gitlab` config struct with `owner`, `repo`, and `url` fields
- Support self-hosted GitLab instances via configurable `url` field (defaults to `https://gitlab.com`)
- Add documentation for GitLab releases configuration
- Update sample config with GitLab target example

## Configuration Example
```yaml
targets:
  gitlab:
    owner: "namespace"
    repo: "project-name"
    url: "https://gitlab.example.com"  # optional, defaults to https://gitlab.com
```

## Testing
Tested manually with gitlab.com:
- ✅ Artifact upload to Generic Package Registry
- ✅ Checksums.txt upload  
- ✅ Release creation with asset links
- ✅ Changelog in release description
- ✅ Downloaded artifacts and verified checksums match

Closes #7